### PR TITLE
Admin sidebar navigation state

### DIFF
--- a/src/components/admin/adminLayout/SideBar.astro
+++ b/src/components/admin/adminLayout/SideBar.astro
@@ -84,6 +84,7 @@ const storefrontUrl = await getSidebarStorefrontUrl();
   class="hidden md:flex md:flex-col bg-sidebar border-r border-sidebar-border sticky top-0 h-screen transition-all duration-300 ease-in-out z-20 sidebar-desktop"
   style="width: var(--sidebar-width, 240px);"
   id="desktop-sidebar"
+  transition:persist="sidebar-desktop"
 >
   <div
     class="flex items-center h-14 px-6 border-b border-sidebar-border bg-sidebar"
@@ -129,79 +130,84 @@ const storefrontUrl = await getSidebarStorefrontUrl();
             <div class="space-y-1">
               {section.items.map((item: NavItem) => (
                 <div class="nav-item-container">
-                  <a
-                    href={
-                      item.subItems && item.subItems.length > 0
-                        ? "javascript:void(0)"
-                        : item.href
-                    }
-                    data-toggle-submenu={
-                      Array.isArray(item.subItems) && item.subItems.length > 0
-                        ? "true"
-                        : undefined
-                    }
-                    data-href={item.href}
-                    data-submenu-key={item.name
-                      .toLowerCase()
-                      .replace(/\s+/g, "-")}
-                    data-is-settings={
-                      item.name.toLowerCase() === "settings"
-                        ? "true"
-                        : undefined
-                    }
-                    class:list={[
-                      "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200 relative sidebar-nav-item hover:scale-[1.02]",
-                      path === item.href ||
-                      (item.subItems &&
-                        item.subItems.some((sub) => path === sub.href))
-                        ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm border border-sidebar-border"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
-                    ]}
-                  >
-                    <item.icon
-                      className={`w-5 h-5 shrink-0 sidebar-nav-icon transition-all duration-200 ${
+                  {Array.isArray(item.subItems) && item.subItems.length > 0 ? (
+                    <button
+                      type="button"
+                      data-toggle-submenu="true"
+                      data-sidebar-parent="true"
+                      data-href={item.href}
+                      data-submenu-key={item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}
+                      data-is-settings={
+                        item.name.toLowerCase() === "settings"
+                          ? "true"
+                          : undefined
+                      }
+                      aria-expanded={path.startsWith(item.href) ? "true" : "false"}
+                      aria-controls={`desktop-submenu-${item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}`}
+                      class:list={[
+                        "group flex w-full items-center gap-3 rounded-lg border border-transparent bg-transparent px-3 py-2.5 text-left text-sm font-medium text-sidebar-foreground transition-all duration-200 relative sidebar-nav-item hover:scale-[1.02] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground cursor-pointer",
                         path === item.href ||
                         (item.subItems &&
                           item.subItems.some((sub) => path === sub.href))
-                          ? "text-sidebar-accent-foreground"
-                          : "text-muted-foreground group-hover:text-sidebar-accent-foreground"
-                      }`}
-                      strokeWidth={2}
-                    />
-                    <span class="sidebar-nav-text flex-1">{item.name}</span>
-                    {Array.isArray(item.subItems) &&
-                      item.subItems.length > 0 && (
-                        <ChevronDown
-                          className={`submenu-chevron w-4 h-4 transition-all duration-300 sidebar-chevron ${
-                            path.startsWith(item.href) && path !== item.href
-                              ? "text-muted-foreground rotate-180"
-                              : path.startsWith(item.href)
-                                ? "text-muted-foreground"
-                                : "text-muted-foreground/70"
-                          }`}
-                        />
-                      )}
-                  </a>
+                          ? "is-active"
+                          : undefined,
+                      ]}
+                    >
+                      <item.icon
+                        className="w-5 h-5 shrink-0 sidebar-nav-icon text-muted-foreground transition-all duration-200 group-hover:text-sidebar-accent-foreground"
+                        strokeWidth={2}
+                      />
+                      <span class="sidebar-nav-text flex-1">{item.name}</span>
+                      <ChevronDown
+                        className={`submenu-chevron w-4 h-4 text-muted-foreground/70 transition-all duration-300 sidebar-chevron ${
+                          path.startsWith(item.href) ? "rotate-180" : ""
+                        }`}
+                      />
+                    </button>
+                  ) : (
+                    <a
+                      href={item.href}
+                      data-sidebar-link="true"
+                      data-sidebar-item-href={item.href}
+                      class:list={[
+                        "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg border border-transparent text-sidebar-foreground transition-all duration-200 relative sidebar-nav-item hover:scale-[1.02] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+                        path === item.href ? "is-active" : undefined,
+                      ]}
+                      aria-current={path === item.href ? "page" : undefined}
+                    >
+                      <item.icon
+                        className="w-5 h-5 shrink-0 sidebar-nav-icon text-muted-foreground transition-all duration-200 group-hover:text-sidebar-accent-foreground"
+                        strokeWidth={2}
+                      />
+                      <span class="sidebar-nav-text flex-1">{item.name}</span>
+                    </a>
+                  )}
 
                   {Array.isArray(item.subItems) && item.subItems.length > 0 && (
-                    <div class="submenu-container ml-6 mt-1 space-y-1 sidebar-submenu overflow-hidden transition-all duration-300 ease-in-out">
+                    <div
+                      id={`desktop-submenu-${item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}`}
+                      class="submenu-container ml-6 mt-1 space-y-1 sidebar-submenu overflow-hidden transition-all duration-300 ease-in-out"
+                    >
                       {item.subItems.map((subItem: NavSubItem) => (
                         <a
                           href={subItem.href}
+                          data-sidebar-subitem="true"
+                          data-sidebar-item-href={subItem.href}
                           class:list={[
-                            "group flex items-center gap-3 px-3 py-2 text-sm rounded-lg transition-all duration-200 sidebar-subnav-item hover:scale-[1.01] hover:translate-x-1",
-                            path === subItem.href
-                              ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium shadow-sm"
-                              : "text-muted-foreground hover:bg-sidebar-accent/30 hover:text-sidebar-accent-foreground",
+                            "group flex items-center gap-3 px-3 py-2 text-sm rounded-lg text-muted-foreground transition-all duration-200 sidebar-subnav-item hover:scale-[1.01] hover:translate-x-1 hover:bg-sidebar-accent/30 hover:text-sidebar-accent-foreground",
+                            path === subItem.href ? "is-active" : undefined,
                           ]}
+                          aria-current={path === subItem.href ? "page" : undefined}
                         >
                           {subItem.icon && (
                             <subItem.icon
-                              className={`w-4 h-4 shrink-0 sidebar-subnav-icon transition-all duration-200 ${
-                                path === subItem.href
-                                  ? "text-sidebar-accent-foreground"
-                                  : "text-muted-foreground group-hover:text-sidebar-accent-foreground"
-                              }`}
+                              className="w-4 h-4 shrink-0 sidebar-subnav-icon text-muted-foreground transition-all duration-200 group-hover:text-sidebar-accent-foreground"
                               strokeWidth={2}
                             />
                           )}
@@ -299,78 +305,83 @@ const storefrontUrl = await getSidebarStorefrontUrl();
             <div class="space-y-1">
               {section.items.map((item: NavItem) => (
                 <div class="nav-item-container">
-                  <a
-                    href={
-                      item.subItems && item.subItems.length > 0
-                        ? "javascript:void(0)"
-                        : item.href
-                    }
-                    data-toggle-submenu={
-                      Array.isArray(item.subItems) && item.subItems.length > 0
-                        ? "true"
-                        : undefined
-                    }
-                    data-href={item.href}
-                    data-submenu-key={item.name
-                      .toLowerCase()
-                      .replace(/\s+/g, "-")}
-                    data-is-settings={
-                      item.name.toLowerCase() === "settings"
-                        ? "true"
-                        : undefined
-                    }
-                    class:list={[
-                      "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200 relative",
-                      path === item.href ||
-                      (item.subItems &&
-                        item.subItems.some((sub) => path === sub.href))
-                        ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm border border-sidebar-border"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
-                    ]}
-                  >
-                    <item.icon
-                      className={`w-5 h-5 shrink-0 ${
+                  {Array.isArray(item.subItems) && item.subItems.length > 0 ? (
+                    <button
+                      type="button"
+                      data-toggle-submenu="true"
+                      data-sidebar-parent="true"
+                      data-href={item.href}
+                      data-submenu-key={item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}
+                      data-is-settings={
+                        item.name.toLowerCase() === "settings"
+                          ? "true"
+                          : undefined
+                      }
+                      aria-expanded={path.startsWith(item.href) ? "true" : "false"}
+                      aria-controls={`mobile-submenu-${item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}`}
+                      class:list={[
+                        "group flex w-full items-center gap-3 rounded-lg border border-transparent bg-transparent px-3 py-2.5 text-left text-sm font-medium text-sidebar-foreground transition-all duration-200 relative hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground cursor-pointer",
                         path === item.href ||
                         (item.subItems &&
                           item.subItems.some((sub) => path === sub.href))
-                          ? "text-sidebar-accent-foreground"
-                          : "text-muted-foreground group-hover:text-sidebar-accent-foreground"
-                      }`}
-                      strokeWidth={2}
-                    />
-                    <span class="flex-1">{item.name}</span>
-                    {Array.isArray(item.subItems) &&
-                      item.subItems.length > 0 && (
-                        <ChevronDown
-                          className={`submenu-chevron w-4 h-4 transition-all duration-300 ${
-                            path.startsWith(item.href) && path !== item.href
-                              ? "text-muted-foreground rotate-180"
-                              : path.startsWith(item.href)
-                                ? "text-muted-foreground"
-                                : "text-muted-foreground/70"
-                          }`}
-                        />
-                      )}
-                  </a>
+                          ? "is-active"
+                          : undefined,
+                      ]}
+                    >
+                      <item.icon
+                        className="w-5 h-5 shrink-0 text-muted-foreground group-hover:text-sidebar-accent-foreground"
+                        strokeWidth={2}
+                      />
+                      <span class="flex-1">{item.name}</span>
+                      <ChevronDown
+                        className={`submenu-chevron w-4 h-4 text-muted-foreground/70 transition-all duration-300 ${
+                          path.startsWith(item.href) ? "rotate-180" : ""
+                        }`}
+                      />
+                    </button>
+                  ) : (
+                    <a
+                      href={item.href}
+                      data-sidebar-link="true"
+                      data-sidebar-item-href={item.href}
+                      class:list={[
+                        "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg border border-transparent text-sidebar-foreground transition-all duration-200 relative hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+                        path === item.href ? "is-active" : undefined,
+                      ]}
+                      aria-current={path === item.href ? "page" : undefined}
+                    >
+                      <item.icon
+                        className="w-5 h-5 shrink-0 text-muted-foreground group-hover:text-sidebar-accent-foreground"
+                        strokeWidth={2}
+                      />
+                      <span class="flex-1">{item.name}</span>
+                    </a>
+                  )}
                   {Array.isArray(item.subItems) && item.subItems.length > 0 && (
-                    <div class="submenu-container ml-6 mt-1 space-y-1 overflow-hidden transition-all duration-300 ease-in-out">
+                    <div
+                      id={`mobile-submenu-${item.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}`}
+                      class="submenu-container ml-6 mt-1 space-y-1 overflow-hidden transition-all duration-300 ease-in-out"
+                    >
                       {item.subItems.map((subItem: NavSubItem) => (
                         <a
                           href={subItem.href}
+                          data-sidebar-subitem="true"
+                          data-sidebar-item-href={subItem.href}
                           class:list={[
-                            "group flex items-center gap-3 px-3 py-2 text-sm rounded-lg transition-all duration-200",
-                            path === subItem.href
-                              ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                              : "text-muted-foreground hover:bg-sidebar-accent/30 hover:text-sidebar-accent-foreground",
+                            "group flex items-center gap-3 px-3 py-2 text-sm rounded-lg text-muted-foreground transition-all duration-200 hover:bg-sidebar-accent/30 hover:text-sidebar-accent-foreground",
+                            path === subItem.href ? "is-active" : undefined,
                           ]}
+                          aria-current={path === subItem.href ? "page" : undefined}
                         >
                           {subItem.icon && (
                             <subItem.icon
-                              className={`w-4 h-4 shrink-0 ${
-                                path === subItem.href
-                                  ? "text-sidebar-accent-foreground"
-                                  : "text-muted-foreground group-hover:text-sidebar-accent-foreground"
-                              }`}
+                              className="w-4 h-4 shrink-0 text-muted-foreground group-hover:text-sidebar-accent-foreground"
                               strokeWidth={2}
                             />
                           )}
@@ -410,7 +421,7 @@ const storefrontUrl = await getSidebarStorefrontUrl();
   </div>
 </aside>
 
-<script is:inline define:vars={{ currentPath }}>
+<script is:inline>
   /**
    * Admin Sidebar Component
    *
@@ -435,302 +446,386 @@ const storefrontUrl = await getSidebarStorefrontUrl();
    * - Graceful handling of localStorage errors
    */
 
-  // Element references
-  const mobileSidebarEl = document.getElementById("mobile-sidebar");
-  const sidebarOverlayEl = document.getElementById("sidebar-overlay");
-  const closeSidebarBtn = document.getElementById("close-sidebar");
-  const desktopSidebarEl = document.getElementById("desktop-sidebar");
-  const sidebarNavEl = document.getElementById("sidebar-nav");
-
-  let isCollapsed = localStorage.getItem("sidebar-collapsed") === "true";
-
-  // Enhanced state management with better FOUC prevention
   const STORAGE_KEYS = {
     collapsed: "sidebar-collapsed",
     submenus: "sidebar-submenu-states",
     scrollPosition: "sidebar-scroll-position",
   };
+  const sidebarState = window.__adminSidebarState || {
+    globalListenersBound: false,
+    isCollapsed: false,
+    scrollTimeout: null,
+  };
+  window.__adminSidebarState = sidebarState;
 
-  // Apply initial collapsed state immediately to prevent FOUC
-  function applyInitialState() {
-    if (!desktopSidebarEl) return;
-
-    // Remove the pre-collapsed class if it exists
-    document.body.classList.remove("sidebar-pre-collapsed");
-
-    if (isCollapsed) {
-      desktopSidebarEl.style.width = "60px";
-      desktopSidebarEl.classList.add("sidebar-collapsed");
-    } else {
-      desktopSidebarEl.style.width = "240px";
-      desktopSidebarEl.classList.remove("sidebar-collapsed");
-    }
-
-    // Update CSS custom property for smooth transitions
-    document.documentElement.style.setProperty(
-      "--sidebar-width",
-      isCollapsed ? "60px" : "240px"
-    );
+  function getDesktopSidebar() {
+    return document.getElementById("desktop-sidebar");
   }
 
-  // Save/restore submenu states
-  function saveSubmenuStates() {
-    const states = {};
-    document.querySelectorAll("[data-submenu-key]").forEach((item) => {
-      const key = item.getAttribute("data-submenu-key");
-      const submenu = item.parentElement?.querySelector(".submenu-container");
-      if (submenu && key) {
-        states[key] =
-          !submenu.classList.contains("hidden") &&
-          submenu.style.maxHeight !== "0px";
-      }
-    });
-    localStorage.setItem(STORAGE_KEYS.submenus, JSON.stringify(states));
+  function getMobileSidebar() {
+    return document.getElementById("mobile-sidebar");
   }
 
-  function restoreSubmenuStates() {
+  function getSidebarOverlay() {
+    return document.getElementById("sidebar-overlay");
+  }
+
+  function getCloseSidebarButton() {
+    return document.getElementById("close-sidebar");
+  }
+
+  function getSidebarNav() {
+    return document.getElementById("sidebar-nav");
+  }
+
+  function getCurrentPath() {
+    return window.location.pathname;
+  }
+
+  function readStorage(key) {
     try {
-      const states = JSON.parse(
-        localStorage.getItem(STORAGE_KEYS.submenus) || "{}"
-      );
-      Object.entries(states).forEach(([key, isOpen]) => {
-        const item = document.querySelector(`[data-submenu-key="${key}"]`);
-        if (item) {
-          const submenu =
-            item.parentElement?.querySelector(".submenu-container");
-          const chevron = item.querySelector(".submenu-chevron");
-          if (submenu) {
-            if (isOpen) {
-              submenu.classList.remove("hidden");
-              submenu.style.maxHeight = submenu.scrollHeight + "px";
-              if (chevron) chevron.classList.add("rotate-180");
-            } else {
-              submenu.classList.add("hidden");
-              submenu.style.maxHeight = "0px";
-              if (chevron) chevron.classList.remove("rotate-180");
-            }
-          }
-        }
-      });
-    } catch (e) {
-      // Silently handle localStorage errors (e.g., in private browsing mode)
+      return localStorage.getItem(key);
+    } catch (error) {
+      return null;
     }
   }
 
-  // Save/restore scroll position with smart scrolling for settings
-  function saveScrollPosition() {
-    if (sidebarNavEl) {
-      localStorage.setItem(
-        STORAGE_KEYS.scrollPosition,
-        sidebarNavEl.scrollTop.toString()
-      );
+  function writeStorage(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (error) {
+      // Ignore localStorage write failures.
     }
   }
 
-  function restoreScrollPosition() {
-    if (sidebarNavEl) {
-      const scrollPos = localStorage.getItem(STORAGE_KEYS.scrollPosition);
-      if (scrollPos) {
-        sidebarNavEl.scrollTop = parseInt(scrollPos, 10);
-      }
-    }
+  function isExactPathMatch(targetPath) {
+    return getCurrentPath() === targetPath;
   }
 
-  function updateSidebarState() {
-    if (!desktopSidebarEl) return;
-
-    const collapseBtn = document.getElementById("sidebar-collapse");
-    if (!collapseBtn) return;
-
-    const expandedIcon = collapseBtn.querySelector(".sidebar-icon-expanded");
-    const collapsedIcon = collapseBtn.querySelector(".sidebar-icon-collapsed");
-
-    if (isCollapsed) {
-      desktopSidebarEl.style.width = "60px";
-      desktopSidebarEl.classList.add("sidebar-collapsed");
-      expandedIcon?.classList.add("hidden");
-      collapsedIcon?.classList.remove("hidden");
-    } else {
-      desktopSidebarEl.style.width = "240px";
-      desktopSidebarEl.classList.remove("sidebar-collapsed");
-      expandedIcon?.classList.remove("hidden");
-      collapsedIcon?.classList.add("hidden");
+  function isPrefixPathMatch(targetPath) {
+    const currentPath = getCurrentPath();
+    if (targetPath === "/admin") {
+      return currentPath === targetPath;
     }
-
-    // Update CSS custom property for smooth transitions
-    document.documentElement.style.setProperty(
-      "--sidebar-width",
-      isCollapsed ? "60px" : "240px"
+    return (
+      currentPath === targetPath || currentPath.startsWith(`${targetPath}/`)
     );
-
-    localStorage.setItem(STORAGE_KEYS.collapsed, isCollapsed.toString());
   }
 
-  function toggleSidebarCollapse() {
-    isCollapsed = !isCollapsed;
-    updateSidebarState();
+  function getSubmenuContainer(toggleButton) {
+    return toggleButton.parentElement?.querySelector(".submenu-container");
   }
 
-  function toggleMobileSidebar() {
-    mobileSidebarEl?.classList.toggle("-translate-x-full");
-    sidebarOverlayEl?.classList.toggle("opacity-0");
-    sidebarOverlayEl?.classList.toggle("pointer-events-none");
+  function getSubmenuChevron(toggleButton) {
+    return toggleButton.querySelector(".submenu-chevron");
   }
 
-  // Enhanced submenu toggle with smart scrolling for settings
-  function toggleSubmenu(submenu, chevron, save = true) {
-    const isCurrentlyHidden =
-      submenu.classList.contains("hidden") || submenu.style.maxHeight === "0px";
+  function isSubmenuOpen(submenu) {
+    if (!submenu) return false;
+    return (
+      !submenu.classList.contains("hidden") && submenu.style.maxHeight !== "0px"
+    );
+  }
 
-    if (isCurrentlyHidden) {
-      // Note: Scroll handling is done in the click handler to ensure proper timing
+  function setSubmenuOpen(toggleButton, shouldOpen, save = true) {
+    const submenu = getSubmenuContainer(toggleButton);
+    const chevron = getSubmenuChevron(toggleButton);
+
+    if (!submenu) return;
+
+    if (shouldOpen) {
       submenu.classList.remove("hidden");
-      submenu.style.maxHeight = submenu.scrollHeight + "px";
-      if (chevron) chevron.classList.add("rotate-180");
+      submenu.style.maxHeight = `${submenu.scrollHeight}px`;
+      chevron?.classList.add("rotate-180");
     } else {
       submenu.style.maxHeight = "0px";
-      if (chevron) chevron.classList.remove("rotate-180");
-      setTimeout(() => {
+      chevron?.classList.remove("rotate-180");
+      window.setTimeout(() => {
         if (submenu.style.maxHeight === "0px") {
           submenu.classList.add("hidden");
         }
       }, 300);
     }
 
+    toggleButton.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+
     if (save) {
       saveSubmenuStates();
     }
   }
 
-  function initializeSubmenuHandlers() {
+  function syncOpenSubmenuHeights() {
     document
       .querySelectorAll('[data-toggle-submenu="true"]')
       .forEach((toggleButton) => {
-        const submenuContainer =
-          toggleButton.parentElement?.querySelector(".submenu-container");
-        const chevron = toggleButton.querySelector(".submenu-chevron");
-        const itemHref = toggleButton.getAttribute("data-href");
-
-        if (!submenuContainer || !itemHref) return;
-
-        // Check if should be open initially (current path or restored state)
-        let openInitially =
-          currentPath.startsWith(itemHref) && currentPath !== itemHref;
-        if (!openInitially) {
-          submenuContainer.querySelectorAll("a").forEach((subLink) => {
-            if (subLink.getAttribute("href") === currentPath) {
-              openInitially = true;
-            }
-          });
+        const submenu = getSubmenuContainer(toggleButton);
+        if (submenu && isSubmenuOpen(submenu)) {
+          submenu.style.maxHeight = `${submenu.scrollHeight}px`;
         }
-
-        // Set initial state without saving to localStorage
-        if (openInitially) {
-          submenuContainer.classList.remove("hidden");
-          submenuContainer.style.maxHeight =
-            submenuContainer.scrollHeight + "px";
-          if (chevron) chevron.classList.add("rotate-180");
-        } else {
-          submenuContainer.classList.add("hidden");
-          submenuContainer.style.maxHeight = "0px";
-          if (chevron) chevron.classList.remove("rotate-180");
-        }
-
-        // Add click handler
-        toggleButton.addEventListener("click", (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-
-          const isSettings =
-            toggleButton.getAttribute("data-is-settings") === "true";
-
-          // Auto-scroll for Settings dropdown to ensure all submenu items are visible
-          if (isSettings && sidebarNavEl) {
-            // Wait for submenu to fully expand before calculating scroll position
-            setTimeout(() => {
-              const maxScroll =
-                sidebarNavEl.scrollHeight - sidebarNavEl.clientHeight;
-
-              if (maxScroll > 10) {
-                // Scroll to maximum position to ensure Cache Settings is visible above View Store
-                sidebarNavEl.scrollTo({
-                  top: maxScroll,
-                  behavior: "smooth",
-                });
-
-                // Double-check after submenu animation completes
-                setTimeout(() => {
-                  const finalMaxScroll =
-                    sidebarNavEl.scrollHeight - sidebarNavEl.clientHeight;
-                  if (finalMaxScroll > maxScroll) {
-                    sidebarNavEl.scrollTo({
-                      top: finalMaxScroll,
-                      behavior: "smooth",
-                    });
-                  }
-                }, 100);
-              }
-            }, 300);
-          }
-
-          // If collapsed, expand the sidebar and then show the submenu
-          if (isCollapsed) {
-            toggleSidebarCollapse();
-            setTimeout(() => {
-              toggleSubmenu(submenuContainer, chevron);
-            }, 300);
-            return;
-          }
-
-          toggleSubmenu(submenuContainer, chevron);
-        });
       });
   }
 
-  function initializeSidebar() {
-    // Apply initial state immediately to prevent FOUC
-    applyInitialState();
-
-    // Restore submenu states
-    restoreSubmenuStates();
-
-    // Initialize submenu handlers
-    initializeSubmenuHandlers();
-
-    // Restore scroll position after a short delay to ensure content is rendered
-    setTimeout(() => {
-      restoreScrollPosition();
-    }, 100);
-
-    // Save scroll position on scroll with debouncing
-    if (sidebarNavEl) {
-      let scrollTimeout;
-      sidebarNavEl.addEventListener("scroll", () => {
-        clearTimeout(scrollTimeout);
-        scrollTimeout = setTimeout(saveScrollPosition, 150);
+  function saveSubmenuStates() {
+    const states = {};
+    document
+      .querySelectorAll('#desktop-sidebar [data-toggle-submenu="true"]')
+      .forEach((toggleButton) => {
+        const key = toggleButton.getAttribute("data-submenu-key");
+        const submenu = getSubmenuContainer(toggleButton);
+        if (key && submenu) {
+          states[key] = isSubmenuOpen(submenu);
+        }
       });
+    writeStorage(STORAGE_KEYS.submenus, JSON.stringify(states));
+  }
+
+  function getSavedSubmenuStates() {
+    try {
+      return JSON.parse(readStorage(STORAGE_KEYS.submenus) || "{}");
+    } catch (error) {
+      return {};
     }
   }
 
-  // Event listeners
-  window.addEventListener("toggleMobileSidebar", toggleMobileSidebar);
-  window.addEventListener("toggleSidebarCollapse", toggleSidebarCollapse);
-  sidebarOverlayEl?.addEventListener("click", toggleMobileSidebar);
-  closeSidebarBtn?.addEventListener("click", toggleMobileSidebar);
-
-  // Initialize immediately if DOM is ready, otherwise wait for it
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initializeSidebar);
-  } else {
-    // Use requestAnimationFrame to ensure DOM is fully ready and prevent FOUC
-    requestAnimationFrame(initializeSidebar);
+  function parentContainsActiveSubItem(toggleButton) {
+    return Array.from(
+      toggleButton.parentElement?.querySelectorAll("[data-sidebar-subitem]") || []
+    ).some((subItem) => isExactPathMatch(subItem.getAttribute("data-sidebar-item-href")));
   }
 
-  // Save states before page unload
-  window.addEventListener("beforeunload", () => {
-    saveSubmenuStates();
-    saveScrollPosition();
-  });
+  function isParentItemActive(toggleButton) {
+    const itemHref = toggleButton.getAttribute("data-href");
+    if (!itemHref) return false;
+    return isPrefixPathMatch(itemHref) || parentContainsActiveSubItem(toggleButton);
+  }
+
+  function restoreSubmenuStates() {
+    const savedStates = getSavedSubmenuStates();
+
+    document
+      .querySelectorAll('[data-toggle-submenu="true"]')
+      .forEach((toggleButton) => {
+        const key = toggleButton.getAttribute("data-submenu-key");
+        const storedState =
+          key && Object.prototype.hasOwnProperty.call(savedStates, key)
+            ? Boolean(savedStates[key])
+            : false;
+        const shouldOpen = isParentItemActive(toggleButton) || storedState;
+        setSubmenuOpen(toggleButton, shouldOpen, false);
+      });
+  }
+
+  function saveScrollPosition() {
+    const sidebarNavEl = getSidebarNav();
+    if (!sidebarNavEl) return;
+    writeStorage(STORAGE_KEYS.scrollPosition, sidebarNavEl.scrollTop.toString());
+  }
+
+  function restoreScrollPosition() {
+    const sidebarNavEl = getSidebarNav();
+    const scrollPosition = readStorage(STORAGE_KEYS.scrollPosition);
+
+    if (!sidebarNavEl || !scrollPosition) return;
+
+    sidebarNavEl.scrollTop = Number.parseInt(scrollPosition, 10) || 0;
+  }
+
+  function setSidebarCollapsed(shouldCollapse, save = true) {
+    const desktopSidebarEl = getDesktopSidebar();
+    const collapseButton = document.getElementById("sidebar-collapse");
+
+    if (!desktopSidebarEl) return;
+
+    sidebarState.isCollapsed = shouldCollapse;
+    document.body.classList.remove("sidebar-pre-collapsed");
+
+    if (shouldCollapse) {
+      desktopSidebarEl.style.width = "60px";
+      desktopSidebarEl.classList.add("sidebar-collapsed");
+    } else {
+      desktopSidebarEl.style.width = "240px";
+      desktopSidebarEl.classList.remove("sidebar-collapsed");
+    }
+
+    document.documentElement.style.setProperty(
+      "--sidebar-width",
+      shouldCollapse ? "60px" : "240px"
+    );
+
+    if (collapseButton) {
+      collapseButton
+        .querySelector(".sidebar-icon-expanded")
+        ?.classList.toggle("hidden", shouldCollapse);
+      collapseButton
+        .querySelector(".sidebar-icon-collapsed")
+        ?.classList.toggle("hidden", !shouldCollapse);
+    }
+
+    if (save) {
+      writeStorage(STORAGE_KEYS.collapsed, shouldCollapse.toString());
+    }
+
+    requestAnimationFrame(syncOpenSubmenuHeights);
+  }
+
+  function toggleSidebarCollapse() {
+    setSidebarCollapsed(!sidebarState.isCollapsed);
+  }
+
+  function toggleMobileSidebar() {
+    getMobileSidebar()?.classList.toggle("-translate-x-full");
+    getSidebarOverlay()?.classList.toggle("opacity-0");
+    getSidebarOverlay()?.classList.toggle("pointer-events-none");
+  }
+
+  function applyActiveStates() {
+    document.querySelectorAll("[data-sidebar-link]").forEach((link) => {
+      const href = link.getAttribute("data-sidebar-item-href");
+      const isActive = href ? isPrefixPathMatch(href) : false;
+      link.classList.toggle("is-active", isActive);
+      if (isActive) {
+        link.setAttribute("aria-current", "page");
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+
+    document.querySelectorAll("[data-sidebar-subitem]").forEach((link) => {
+      const href = link.getAttribute("data-sidebar-item-href");
+      const isActive = href ? isExactPathMatch(href) : false;
+      link.classList.toggle("is-active", isActive);
+      if (isActive) {
+        link.setAttribute("aria-current", "page");
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+
+    document.querySelectorAll("[data-sidebar-parent]").forEach((toggleButton) => {
+      const isActive = isParentItemActive(toggleButton);
+      toggleButton.classList.toggle("is-active", isActive);
+    });
+  }
+
+  function revealSettingsSubmenu(toggleButton) {
+    const sidebarNavEl = getSidebarNav();
+    const submenu = getSubmenuContainer(toggleButton);
+    const lastSubItem = submenu?.lastElementChild;
+
+    if (
+      !sidebarNavEl ||
+      !submenu ||
+      !lastSubItem ||
+      !toggleButton.closest("#desktop-sidebar")
+    ) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const navRect = sidebarNavEl.getBoundingClientRect();
+        const itemRect = lastSubItem.getBoundingClientRect();
+        const bottomPadding = 16;
+
+        if (itemRect.bottom > navRect.bottom - bottomPadding) {
+          sidebarNavEl.scrollBy({
+            top: itemRect.bottom - (navRect.bottom - bottomPadding),
+            behavior: "smooth",
+          });
+        }
+      });
+    });
+  }
+
+  function bindSubmenuToggleHandlers(rootElement) {
+    if (!rootElement || rootElement.dataset.sidebarBound === "true") return;
+
+    rootElement.addEventListener("click", (event) => {
+      const toggleButton = event.target.closest('[data-toggle-submenu="true"]');
+      if (!toggleButton || !rootElement.contains(toggleButton)) return;
+
+      const isSettings = toggleButton.getAttribute("data-is-settings") === "true";
+
+      if (toggleButton.closest("#desktop-sidebar") && sidebarState.isCollapsed) {
+        setSidebarCollapsed(false);
+        setSubmenuOpen(toggleButton, true);
+      } else {
+        const submenu = getSubmenuContainer(toggleButton);
+        setSubmenuOpen(toggleButton, !isSubmenuOpen(submenu));
+      }
+
+      if (isSettings) {
+        revealSettingsSubmenu(toggleButton);
+      }
+    });
+
+    rootElement.dataset.sidebarBound = "true";
+  }
+
+  function bindScrollPersistence() {
+    const sidebarNavEl = getSidebarNav();
+    if (!sidebarNavEl || sidebarNavEl.dataset.scrollBound === "true") return;
+
+    sidebarNavEl.addEventListener("scroll", () => {
+      window.clearTimeout(sidebarState.scrollTimeout);
+      sidebarState.scrollTimeout = window.setTimeout(saveScrollPosition, 150);
+    });
+
+    sidebarNavEl.dataset.scrollBound = "true";
+  }
+
+  function bindStaticControl(control, handler) {
+    if (!control || control.dataset.bound === "true") return;
+    control.addEventListener("click", handler);
+    control.dataset.bound = "true";
+  }
+
+  function bindGlobalListeners() {
+    if (sidebarState.globalListenersBound) return;
+
+    window.addEventListener("toggleMobileSidebar", toggleMobileSidebar);
+    window.addEventListener("toggleSidebarCollapse", toggleSidebarCollapse);
+    window.addEventListener("beforeunload", () => {
+      saveSubmenuStates();
+      saveScrollPosition();
+    });
+
+    document.addEventListener("astro:page-load", () => {
+      applyActiveStates();
+      syncOpenSubmenuHeights();
+    });
+
+    sidebarState.globalListenersBound = true;
+  }
+
+  function initializeSidebar() {
+    const desktopSidebarEl = getDesktopSidebar();
+
+    sidebarState.isCollapsed = readStorage(STORAGE_KEYS.collapsed) === "true";
+    setSidebarCollapsed(sidebarState.isCollapsed, false);
+
+    bindSubmenuToggleHandlers(desktopSidebarEl);
+    bindSubmenuToggleHandlers(getMobileSidebar());
+    bindStaticControl(getSidebarOverlay(), toggleMobileSidebar);
+    bindStaticControl(getCloseSidebarButton(), toggleMobileSidebar);
+    bindScrollPersistence();
+    bindGlobalListeners();
+
+    if (desktopSidebarEl && desktopSidebarEl.dataset.sidebarInitialized !== "true") {
+      restoreSubmenuStates();
+      requestAnimationFrame(restoreScrollPosition);
+      desktopSidebarEl.dataset.sidebarInitialized = "true";
+    }
+
+    applyActiveStates();
+    syncOpenSubmenuHeights();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeSidebar, { once: true });
+  } else {
+    requestAnimationFrame(initializeSidebar);
+  }
 </script>
 
 <style>
@@ -764,6 +859,29 @@ const storefrontUrl = await getSidebarStorefrontUrl();
   .submenu-container:not(.hidden) {
     max-height: 600px;
     opacity: 1;
+  }
+
+  .sidebar-nav-item.is-active {
+    background: oklch(var(--sidebar-accent));
+    color: oklch(var(--sidebar-accent-foreground));
+    border-color: oklch(var(--sidebar-border));
+    box-shadow: 0 1px 2px 0 oklch(var(--sidebar-accent-foreground) / 0.08);
+  }
+
+  .sidebar-nav-item.is-active .sidebar-nav-icon,
+  .sidebar-nav-item.is-active .submenu-chevron {
+    color: oklch(var(--sidebar-accent-foreground));
+  }
+
+  .sidebar-subnav-item.is-active {
+    background: oklch(var(--sidebar-accent));
+    color: oklch(var(--sidebar-accent-foreground));
+    font-weight: 500;
+    box-shadow: 0 1px 2px 0 oklch(var(--sidebar-accent-foreground) / 0.08);
+  }
+
+  .sidebar-subnav-item.is-active .sidebar-subnav-icon {
+    color: oklch(var(--sidebar-accent-foreground));
   }
 
   .sidebar-nav-item {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Reworks the admin sidebar to fix Settings dropdown behavior, ensuring it acts as a toggle, persists state across navigations, and expands correctly when the sidebar is collapsed.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation had several issues: the "Settings" parent item would navigate instead of just toggling, the dropdown would incorrectly close on navigation away from `/admin/settings/*` URLs, and opening the "Settings" dropdown from a collapsed sidebar required two clicks. This PR addresses these by converting parent items to buttons, removing state-clobbering logic, and ensuring immediate dropdown expansion when the sidebar is opened.

---
<p><a href="https://cursor.com/agents/bc-61b6736e-3b00-4bd2-bcce-9ed85969c3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61b6736e-3b00-4bd2-bcce-9ed85969c3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->