### PR TITLE
Rich text editor media

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[1000] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[1001] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[1000] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[1001] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -27,7 +27,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-[200] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-[1100] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/src/components/ui/tiptap-editor.tsx
+++ b/src/components/ui/tiptap-editor.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { useEditor, EditorContent, Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Heading from "@tiptap/extension-heading";
@@ -42,12 +41,17 @@ import {
   ChevronsLeftRight,
   TextQuote,
   Video as VideoIcon,
+  Link2,
+  Library,
 } from "lucide-react";
 import { Button } from "./button";
 import { Input } from "./input";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./tooltip";
 import { Switch } from "./switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+import { MediaManager } from "@/components/admin/media-manager";
+import type { MediaFile } from "@/components/admin/media-manager";
 
 interface TiptapEditorProps {
   content: string;
@@ -95,12 +99,12 @@ function ToolbarButton({
 
 const MenuBar = ({
   editor,
-  toggleModal,
+  toggleFullscreen,
   compact = false,
   isFullscreen = false,
 }: {
   editor: Editor | null;
-  toggleModal: () => void;
+  toggleFullscreen: () => void;
   compact?: boolean;
   isFullscreen?: boolean;
 }) => {
@@ -136,24 +140,47 @@ const MenuBar = ({
     }
   };
 
-  const addImage = () => {
+  /**
+   * Insert block content (image or video) at the end of the document,
+   * bypassing the current selection entirely.
+   *
+   * Why: Tiptap's `focus("end")` on a document whose last child is an atom
+   * node (e.g. an image with `atom: true`) resolves to a NodeSelection on
+   * that atom. Any subsequent `insertContent` call then *replaces* the
+   * selected node. By using `insertContentAt(doc.content.size, ...)` we
+   * always append after all existing content without touching the selection.
+   */
+  const appendContent = (content: object) => {
+    const endPos = editor.state.doc.content.size;
+    editor.commands.insertContentAt(endPos, content);
+    editor.commands.focus();
+  };
+
+  const addImageFromUrl = () => {
     if (!imageUrl) return;
-    const url = imageUrl;
+    const url = imageUrl.trim();
     setImageUrl("");
     setImageOpen(false);
     requestAnimationFrame(() => {
-      editor.chain().focus().setImage({ src: url }).run();
+      appendContent({ type: "image", attrs: { src: url } });
+    });
+  };
+
+  const addImageFromMedia = (file: MediaFile) => {
+    const src = file.url;
+    setImageOpen(false);
+    requestAnimationFrame(() => {
+      appendContent({ type: "image", attrs: { src } });
     });
   };
 
   const addVideo = () => {
     if (!videoUrl) return;
-    const url = videoUrl;
+    const url = videoUrl.trim();
     setVideoUrl("");
     setVideoOpen(false);
     requestAnimationFrame(() => {
-      editor.chain().focus().run();
-      editor.commands.setYoutubeVideo({ src: url });
+      appendContent({ type: "youtube", attrs: { src: url } });
     });
   };
 
@@ -174,480 +201,518 @@ const MenuBar = ({
   const gapSize = compact ? "gap-0.5" : "gap-1";
   const padding = compact ? "p-0.5" : "p-1";
 
-  return (
-    <div className={cn("border border-input rounded-t-md bg-background flex flex-wrap items-center justify-between", padding, gapSize)}>
-      <div className={cn("flex flex-wrap items-center", gapSize)}>
-        {/* Text formatting */}
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleBold().run()}
-          isActive={editor.isActive("bold")}
-          tooltip="Bold (Ctrl+B)"
-          buttonSize={buttonSize}
+  const toolbarContent = (
+    <div className={cn("flex flex-wrap items-center", gapSize)}>
+      {/* Text formatting */}
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        isActive={editor.isActive("bold")}
+        tooltip="Bold (Ctrl+B)"
+        buttonSize={buttonSize}
+      >
+        <Bold className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        isActive={editor.isActive("italic")}
+        tooltip="Italic (Ctrl+I)"
+        buttonSize={buttonSize}
+      >
+        <Italic className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        isActive={editor.isActive("underline")}
+        tooltip="Underline (Ctrl+U)"
+        buttonSize={buttonSize}
+      >
+        <UnderlineIcon className={iconSize} />
+      </ToolbarButton>
 
-        >
-          <Bold className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleItalic().run()}
-          isActive={editor.isActive("italic")}
-          tooltip="Italic (Ctrl+I)"
-          buttonSize={buttonSize}
+      <div className="w-px h-6 bg-border mx-1" />
 
-        >
-          <Italic className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleUnderline().run()}
-          isActive={editor.isActive("underline")}
-          tooltip="Underline (Ctrl+U)"
-          buttonSize={buttonSize}
-
-        >
-          <UnderlineIcon className={iconSize} />
-        </ToolbarButton>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* Links, images, video */}
-        <Popover open={linkOpen} onOpenChange={setLinkOpen}>
-          <Tooltip open={linkOpen ? false : undefined}>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={cn(buttonSize, editor.isActive("link") && "bg-accent")}
-                >
-                  <LinkIcon className={iconSize} />
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={5}>
-              <p className="text-xs">Insert link</p>
-            </TooltipContent>
-          </Tooltip>
-          <PopoverContent className="w-80 p-2" onOpenAutoFocus={(e) => e.preventDefault()}>
-            <div className="flex gap-2">
-              <Input
-                type="url"
-                placeholder="https://example.com"
-                value={linkUrl}
-                onChange={(e) => setLinkUrl(e.target.value)}
-                className="flex-1"
-                onKeyDown={(e) => e.key === "Enter" && setLink()}
-              />
-              <Button type="button" size="sm" onClick={setLink}>
-                Set
-              </Button>
-            </div>
-          </PopoverContent>
-        </Popover>
-
-        <Popover open={imageOpen} onOpenChange={setImageOpen}>
-          <Tooltip open={imageOpen ? false : undefined}>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={buttonSize}
-                >
-                  <ImageIcon className={iconSize} />
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={5}>
-              <p className="text-xs">Insert image</p>
-            </TooltipContent>
-          </Tooltip>
-          <PopoverContent className="w-80 p-2" onOpenAutoFocus={(e) => e.preventDefault()}>
-            <div className="flex gap-2">
-              <Input
-                type="url"
-                placeholder="https://example.com/image.jpg"
-                value={imageUrl}
-                onChange={(e) => setImageUrl(e.target.value)}
-                className="flex-1"
-                onKeyDown={(e) => e.key === "Enter" && addImage()}
-              />
-              <Button type="button" size="sm" onClick={addImage}>
-                Add
-              </Button>
-            </div>
-          </PopoverContent>
-        </Popover>
-
-        <Popover open={videoOpen} onOpenChange={setVideoOpen}>
-          <Tooltip open={videoOpen ? false : undefined}>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={buttonSize}
-                >
-                  <VideoIcon className={iconSize} />
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={5}>
-              <p className="text-xs">Embed video</p>
-            </TooltipContent>
-          </Tooltip>
-          <PopoverContent className="w-80 p-2" onOpenAutoFocus={(e) => e.preventDefault()}>
-            <div className="flex gap-2">
-              <Input
-                type="url"
-                placeholder="https://youtube.com/watch?v=..."
-                value={videoUrl}
-                onChange={(e) => setVideoUrl(e.target.value)}
-                className="flex-1"
-                onKeyDown={(e) => e.key === "Enter" && addVideo()}
-              />
-              <Button type="button" size="sm" onClick={addVideo}>
-                Embed
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground mt-1.5">
-              Supports YouTube and Vimeo URLs
-            </p>
-          </PopoverContent>
-        </Popover>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* Alignment */}
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign("left").run()}
-          isActive={editor.isActive({ textAlign: "left" })}
-          tooltip="Align left"
-          buttonSize={buttonSize}
-
-        >
-          <AlignLeft className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign("center").run()}
-          isActive={editor.isActive({ textAlign: "center" })}
-          tooltip="Align center"
-          buttonSize={buttonSize}
-
-        >
-          <AlignCenter className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign("right").run()}
-          isActive={editor.isActive({ textAlign: "right" })}
-          tooltip="Align right"
-          buttonSize={buttonSize}
-
-        >
-          <AlignRight className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().setTextAlign("justify").run()}
-          isActive={editor.isActive({ textAlign: "justify" })}
-          tooltip="Justify"
-          buttonSize={buttonSize}
-
-        >
-          <AlignJustify className={iconSize} />
-        </ToolbarButton>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* Headings */}
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-          isActive={editor.isActive("heading", { level: 1 })}
-          tooltip="Heading 1"
-          buttonSize={buttonSize}
-
-        >
-          <Heading1 className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-          isActive={editor.isActive("heading", { level: 2 })}
-          tooltip="Heading 2"
-          buttonSize={buttonSize}
-
-        >
-          <Heading2 className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-          isActive={editor.isActive("heading", { level: 3 })}
-          tooltip="Heading 3"
-          buttonSize={buttonSize}
-
-        >
-          <Heading3 className={iconSize} />
-        </ToolbarButton>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* Lists & blockquote */}
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleBulletList().run()}
-          isActive={editor.isActive("bulletList")}
-          tooltip="Bullet list"
-          buttonSize={buttonSize}
-
-        >
-          <List className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleOrderedList().run()}
-          isActive={editor.isActive("orderedList")}
-          tooltip="Numbered list"
-          buttonSize={buttonSize}
-
-        >
-          <ListOrdered className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          isActive={editor.isActive("blockquote")}
-          tooltip="Blockquote"
-          buttonSize={buttonSize}
-
-        >
-          <TextQuote className={iconSize} />
-        </ToolbarButton>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* Table */}
-        <Popover>
-          <PopoverTrigger asChild>
-            <span>
-              <ToolbarButton
-                onClick={() => { }}
-                tooltip="Insert table"
-                buttonSize={buttonSize}
-
+      {/* Link */}
+      <Popover open={linkOpen} onOpenChange={setLinkOpen}>
+        <Tooltip open={linkOpen ? false : undefined}>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(buttonSize, editor.isActive("link") && "bg-accent")}
               >
-                <TableIcon className={iconSize} />
-              </ToolbarButton>
-            </span>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-2 space-y-2">
-            <div className="grid grid-cols-2 gap-2 items-center">
-              <Input
-                type="number"
-                value={tableRows}
-                onChange={(e) => setTableRows(e.target.value)}
-                placeholder="Rows"
-                className="h-8 text-xs"
-                min="1"
-              />
-              <Input
-                type="number"
-                value={tableCols}
-                onChange={(e) => setTableCols(e.target.value)}
-                placeholder="Cols"
-                className="h-8 text-xs"
-                min="1"
-              />
-            </div>
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="table-header"
-                checked={tableWithHeader}
-                onCheckedChange={setTableWithHeader}
-              />
-              <label
-                htmlFor="table-header"
-                className="text-xs text-muted-foreground"
+                <LinkIcon className={iconSize} />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={5}>
+            <p className="text-xs">Insert link</p>
+          </TooltipContent>
+        </Tooltip>
+        <PopoverContent className="w-80 p-2" onOpenAutoFocus={(e) => e.preventDefault()}>
+          <div className="flex gap-2">
+            <Input
+              type="url"
+              placeholder="https://example.com"
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+              className="flex-1"
+              onKeyDown={(e) => e.key === "Enter" && setLink()}
+            />
+            <Button type="button" size="sm" onClick={setLink}>
+              Set
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Image with URL + Media Library tabs */}
+      <Popover open={imageOpen} onOpenChange={setImageOpen}>
+        <Tooltip open={imageOpen ? false : undefined}>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={buttonSize}
               >
-                Include header row
-              </label>
-            </div>
+                <ImageIcon className={iconSize} />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={5}>
+            <p className="text-xs">Insert image</p>
+          </TooltipContent>
+        </Tooltip>
+        <PopoverContent
+          className="w-[420px] p-3"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <Tabs defaultValue="url">
+            <TabsList className="w-full mb-3">
+              <TabsTrigger value="url" className="flex-1 gap-1.5 text-xs">
+                <Link2 className="h-3.5 w-3.5" />
+                From URL
+              </TabsTrigger>
+              <TabsTrigger value="library" className="flex-1 gap-1.5 text-xs">
+                <Library className="h-3.5 w-3.5" />
+                Media Library
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="url" className="mt-0">
+              <div className="flex gap-2">
+                <Input
+                  type="url"
+                  placeholder="https://example.com/image.jpg"
+                  value={imageUrl}
+                  onChange={(e) => setImageUrl(e.target.value)}
+                  className="flex-1 text-sm"
+                  onKeyDown={(e) => e.key === "Enter" && addImageFromUrl()}
+                  autoFocus
+                />
+                <Button type="button" size="sm" onClick={addImageFromUrl}>
+                  Add
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Paste a direct link to an image (jpg, png, webp, gif…)
+              </p>
+            </TabsContent>
+
+            <TabsContent value="library" className="mt-0">
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  Select an image from your media library to insert it.
+                </p>
+                <MediaManager
+                  onSelect={addImageFromMedia}
+                  triggerLabel="Browse Media Library"
+                  acceptedFileTypes="image/*"
+                />
+              </div>
+            </TabsContent>
+          </Tabs>
+        </PopoverContent>
+      </Popover>
+
+      {/* Video / YouTube embed */}
+      <Popover open={videoOpen} onOpenChange={setVideoOpen}>
+        <Tooltip open={videoOpen ? false : undefined}>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={buttonSize}
+              >
+                <VideoIcon className={iconSize} />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={5}>
+            <p className="text-xs">Embed video</p>
+          </TooltipContent>
+        </Tooltip>
+        <PopoverContent className="w-80 p-2" onOpenAutoFocus={(e) => e.preventDefault()}>
+          <div className="flex gap-2">
+            <Input
+              type="url"
+              placeholder="https://youtube.com/watch?v=..."
+              value={videoUrl}
+              onChange={(e) => setVideoUrl(e.target.value)}
+              className="flex-1"
+              onKeyDown={(e) => e.key === "Enter" && addVideo()}
+            />
+            <Button type="button" size="sm" onClick={addVideo}>
+              Embed
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground mt-1.5">
+            Supports YouTube and Vimeo URLs
+          </p>
+        </PopoverContent>
+      </Popover>
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Alignment */}
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign("left").run()}
+        isActive={editor.isActive({ textAlign: "left" })}
+        tooltip="Align left"
+        buttonSize={buttonSize}
+      >
+        <AlignLeft className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign("center").run()}
+        isActive={editor.isActive({ textAlign: "center" })}
+        tooltip="Align center"
+        buttonSize={buttonSize}
+      >
+        <AlignCenter className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign("right").run()}
+        isActive={editor.isActive({ textAlign: "right" })}
+        tooltip="Align right"
+        buttonSize={buttonSize}
+      >
+        <AlignRight className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign("justify").run()}
+        isActive={editor.isActive({ textAlign: "justify" })}
+        tooltip="Justify"
+        buttonSize={buttonSize}
+      >
+        <AlignJustify className={iconSize} />
+      </ToolbarButton>
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Headings */}
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        isActive={editor.isActive("heading", { level: 1 })}
+        tooltip="Heading 1"
+        buttonSize={buttonSize}
+      >
+        <Heading1 className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        isActive={editor.isActive("heading", { level: 2 })}
+        tooltip="Heading 2"
+        buttonSize={buttonSize}
+      >
+        <Heading2 className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        isActive={editor.isActive("heading", { level: 3 })}
+        tooltip="Heading 3"
+        buttonSize={buttonSize}
+      >
+        <Heading3 className={iconSize} />
+      </ToolbarButton>
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Lists & blockquote */}
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        isActive={editor.isActive("bulletList")}
+        tooltip="Bullet list"
+        buttonSize={buttonSize}
+      >
+        <List className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        isActive={editor.isActive("orderedList")}
+        tooltip="Numbered list"
+        buttonSize={buttonSize}
+      >
+        <ListOrdered className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        isActive={editor.isActive("blockquote")}
+        tooltip="Blockquote"
+        buttonSize={buttonSize}
+      >
+        <TextQuote className={iconSize} />
+      </ToolbarButton>
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Table */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <span>
+            <ToolbarButton
+              onClick={() => {}}
+              tooltip="Insert table"
+              buttonSize={buttonSize}
+            >
+              <TableIcon className={iconSize} />
+            </ToolbarButton>
+          </span>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-2 space-y-2">
+          <div className="grid grid-cols-2 gap-2 items-center">
+            <Input
+              type="number"
+              value={tableRows}
+              onChange={(e) => setTableRows(e.target.value)}
+              placeholder="Rows"
+              className="h-8 text-xs"
+              min="1"
+            />
+            <Input
+              type="number"
+              value={tableCols}
+              onChange={(e) => setTableCols(e.target.value)}
+              placeholder="Cols"
+              className="h-8 text-xs"
+              min="1"
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="table-header"
+              checked={tableWithHeader}
+              onCheckedChange={setTableWithHeader}
+            />
+            <label
+              htmlFor="table-header"
+              className="text-xs text-muted-foreground"
+            >
+              Include header row
+            </label>
+          </div>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={addTable}
+            className="w-full text-xs"
+          >
+            <TableIcon className="h-3 w-3 mr-1" /> Insert Table
+          </Button>
+
+          <hr className="my-2" />
+          <p className="text-xs font-medium text-muted-foreground mb-1">
+            Quick Actions:
+          </p>
+          <div className="grid grid-cols-3 gap-1">
             <Button
               type="button"
-              variant="default"
+              variant="ghost"
               size="sm"
-              onClick={addTable}
-              className="w-full text-xs"
+              onClick={() => editor.chain().focus().addColumnBefore().run()}
+              disabled={!editor.can().addColumnBefore()}
+              className="flex items-center gap-1 text-xs"
             >
-              <TableIcon className="h-3 w-3 mr-1" /> Insert Table
+              <ChevronsLeftRight className="h-3 w-3 transform rotate-90" />{" "}
+              Col Before
             </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().addColumnAfter().run()}
+              disabled={!editor.can().addColumnAfter()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <ChevronsLeftRight className="h-3 w-3 transform rotate-90" />{" "}
+              Col After
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().deleteColumn().run()}
+              disabled={!editor.can().deleteColumn()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Columns className="h-3 w-3" /> Del Col
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().addRowBefore().run()}
+              disabled={!editor.can().addRowBefore()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Rows className="h-3 w-3" /> Row Before
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().addRowAfter().run()}
+              disabled={!editor.can().addRowAfter()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Rows className="h-3 w-3" /> Row After
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().deleteRow().run()}
+              disabled={!editor.can().deleteRow()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Rows className="h-3 w-3" /> Del Row
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().deleteTable().run()}
+              disabled={!editor.can().deleteTable()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Eraser className="h-3 w-3" /> Del Table
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().mergeCells().run()}
+              disabled={!editor.can().mergeCells()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Merge className="h-3 w-3" /> Merge
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().splitCell().run()}
+              disabled={!editor.can().splitCell()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Split className="h-3 w-3" /> Split
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                editor.chain().focus().toggleHeaderColumn().run()
+              }
+              disabled={!editor.can().toggleHeaderColumn()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <ChevronsLeftRight className="h-3 w-3" /> H Col
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().toggleHeaderRow().run()}
+              disabled={!editor.can().toggleHeaderRow()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <Rows className="h-3 w-3" /> H Row
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => editor.chain().focus().toggleHeaderCell().run()}
+              disabled={!editor.can().toggleHeaderCell()}
+              className="flex items-center gap-1 text-xs"
+            >
+              <TableIcon className="h-3 w-3" /> H Cell
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
 
-            <hr className="my-2" />
-            <p className="text-xs font-medium text-muted-foreground mb-1">
-              Quick Actions:
-            </p>
-            <div className="grid grid-cols-3 gap-1">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().addColumnBefore().run()}
-                disabled={!editor.can().addColumnBefore()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <ChevronsLeftRight className="h-3 w-3 transform rotate-90" />{" "}
-                Col Before
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().addColumnAfter().run()}
-                disabled={!editor.can().addColumnAfter()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <ChevronsLeftRight className="h-3 w-3 transform rotate-90" />{" "}
-                Col After
-              </Button>
+      <div className="w-px h-6 bg-border mx-1" />
 
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().deleteColumn().run()}
-                disabled={!editor.can().deleteColumn()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Columns className="h-3 w-3" /> Del Col
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().addRowBefore().run()}
-                disabled={!editor.can().addRowBefore()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Rows className="h-3 w-3" /> Row Before
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().addRowAfter().run()}
-                disabled={!editor.can().addRowAfter()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Rows className="h-3 w-3" /> Row After
-              </Button>
+      {/* History */}
+      <ToolbarButton
+        onClick={() => editor.chain().focus().undo().run()}
+        disabled={!editor.can().undo()}
+        tooltip="Undo (Ctrl+Z)"
+        buttonSize={buttonSize}
+      >
+        <Undo className={iconSize} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().redo().run()}
+        disabled={!editor.can().redo()}
+        tooltip="Redo (Ctrl+Shift+Z)"
+        buttonSize={buttonSize}
+      >
+        <Redo className={iconSize} />
+      </ToolbarButton>
+    </div>
+  );
 
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().deleteRow().run()}
-                disabled={!editor.can().deleteRow()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Rows className="h-3 w-3" /> Del Row
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().deleteTable().run()}
-                disabled={!editor.can().deleteTable()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Eraser className="h-3 w-3" /> Del Table
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().mergeCells().run()}
-                disabled={!editor.can().mergeCells()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Merge className="h-3 w-3" /> Merge
-              </Button>
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().splitCell().run()}
-                disabled={!editor.can().splitCell()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Split className="h-3 w-3" /> Split
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() =>
-                  editor.chain().focus().toggleHeaderColumn().run()
-                }
-                disabled={!editor.can().toggleHeaderColumn()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <ChevronsLeftRight className="h-3 w-3" /> H Col
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().toggleHeaderRow().run()}
-                disabled={!editor.can().toggleHeaderRow()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <Rows className="h-3 w-3" /> H Row
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => editor.chain().focus().toggleHeaderCell().run()}
-                disabled={!editor.can().toggleHeaderCell()}
-                className="flex items-center gap-1 text-xs"
-              >
-                <TableIcon className="h-3 w-3" /> H Cell
-              </Button>
-            </div>
-          </PopoverContent>
-        </Popover>
-
-        <div className="w-px h-6 bg-border mx-1" />
-
-        {/* History */}
-        <ToolbarButton
-          onClick={() => editor.chain().focus().undo().run()}
-          disabled={!editor.can().undo()}
-          tooltip="Undo (Ctrl+Z)"
-          buttonSize={buttonSize}
-
-        >
-          <Undo className={iconSize} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => editor.chain().focus().redo().run()}
-          disabled={!editor.can().redo()}
-          tooltip="Redo (Ctrl+Shift+Z)"
-          buttonSize={buttonSize}
-
-        >
-          <Redo className={iconSize} />
-        </ToolbarButton>
-      </div>
-
-      {/* Fullscreen toggle */}
-      {!isFullscreen && (
-        <div>
+  return (
+    <div
+      className={cn(
+        "border border-input bg-background flex flex-wrap items-center justify-between",
+        isFullscreen ? "rounded-none border-x-0 border-t-0" : "rounded-t-md",
+        padding,
+        gapSize,
+      )}
+    >
+      {isFullscreen ? (
+        <div className="w-full max-w-4xl mx-auto flex flex-wrap items-center justify-between gap-1">
+          {toolbarContent}
+          {/* Minimize button inside centered toolbar row */}
           <ToolbarButton
-            onClick={toggleModal}
+            onClick={toggleFullscreen}
+            tooltip="Exit fullscreen (Esc)"
+            buttonSize={buttonSize}
+          >
+            <Minimize2 className={iconSize} />
+          </ToolbarButton>
+        </div>
+      ) : (
+        <>
+          {toolbarContent}
+          <ToolbarButton
+            onClick={toggleFullscreen}
             tooltip="Fullscreen"
             buttonSize={buttonSize}
-
           >
             <Maximize className={iconSize} />
           </ToolbarButton>
-        </div>
+        </>
       )}
     </div>
   );
@@ -662,14 +727,16 @@ export function TiptapEditor({
 }: TiptapEditorProps) {
   const [isMounted, setIsMounted] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
-  // Handle Escape key and body scroll lock for fullscreen
+  // Handle Escape key, body scroll lock, and admin layout z-index elevation when fullscreen
   useEffect(() => {
     if (!isFullscreen) return;
+
     const previousBodyOverflow = document.body.style.overflow;
     const previousBodyPaddingRight = document.body.style.paddingRight;
     const previousHtmlOverflow = document.documentElement.style.overflow;
@@ -689,11 +756,40 @@ export function TiptapEditor({
       document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
 
+    /**
+     * The admin layout's <main id="main-content"> has Astro's
+     * `transition:name="admin-main-content"` which compiles to
+     * `view-transition-name: admin-main-content` in CSS.
+     *
+     * Per CSS spec, any non-none `view-transition-name` CREATES A STACKING
+     * CONTEXT on the element. Because <main>'s stacking context has `z-index:
+     * auto` (level 7 in root), it paints BELOW positioned elements with
+     * explicit z-indices like the sidebar (z-20, level 8) and header (z-30,
+     * level 8). This traps our `position:fixed` fullscreen overlay inside
+     * <main>'s stacking context so it never appears above the sidebar/header,
+     * regardless of how high we set its z-index.
+     *
+     * Fix: Temporarily override `view-transition-name` to `none` during
+     * fullscreen. This removes the stacking context from <main>, allowing the
+     * fixed editor (z-[999]) to participate directly in the root stacking
+     * context and appear above everything (sidebar, header, etc.).
+     * Dialogs/popovers portaled to <body> at z-[1000+] still float above it.
+     * We restore the original value on exit.
+     */
+    const mainEl = document.getElementById("main-content");
+    const prevMainViewTransitionName = mainEl?.style.viewTransitionName ?? "";
+    if (mainEl) {
+      mainEl.style.viewTransitionName = "none";
+    }
+
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.body.style.overflow = previousBodyOverflow;
       document.body.style.paddingRight = previousBodyPaddingRight;
       document.documentElement.style.overflow = previousHtmlOverflow;
+      if (mainEl) {
+        mainEl.style.viewTransitionName = prevMainViewTransitionName;
+      }
     };
   }, [isFullscreen]);
 
@@ -762,6 +858,7 @@ export function TiptapEditor({
     immediatelyRender: false,
   });
 
+  // Sync content from outside (e.g., form reset)
   useEffect(() => {
     if (editorInstance && content !== editorInstance.getHTML() && isMounted) {
       editorInstance.commands.setContent(content);
@@ -771,7 +868,7 @@ export function TiptapEditor({
   if (!isMounted) {
     return (
       <div className={cn("border rounded-md", className)}>
-        <div className="border border-input rounded-t-md p-1 bg-background h-10"></div>
+        <div className="border border-input rounded-t-md p-1 bg-background h-10" />
         <div className="max-w-none p-4 min-h-[200px] focus-visible:outline-none text-sm border-t">
           <div className="text-muted-foreground">{placeholder}</div>
         </div>
@@ -779,68 +876,62 @@ export function TiptapEditor({
     );
   }
 
-  const editorContent = (
+  return (
+    /**
+     * CSS-only fullscreen: position:fixed keeps the editor in the same React
+     * tree (no portal, no unmount/remount) so embedded iframes (YouTube) and
+     * images survive the transition without glitching or disappearing.
+     *
+     * Z-index strategy (must stay consistent with dialog.tsx / alert-dialog.tsx
+     * / popover.tsx / tooltip.tsx):
+     *   z-[999]  — fullscreen editor (covers admin header z-30, sidebar z-20/50)
+     *   z-[1000] — Dialog / AlertDialog overlays (e.g. MediaManager, above editor)
+     *   z-[1001] — Dialog / AlertDialog content
+     *   z-[1100] — Popovers & Tooltips (always topmost)
+     */
     <div
+      ref={wrapperRef}
       className={cn(
         "flex flex-col bg-background",
         isFullscreen
-          ? "fixed inset-0 z-[999] h-dvh w-screen"
-          : "border rounded-md",
-        !isFullscreen && className,
+          ? "fixed inset-0 z-[999] h-dvh w-screen overflow-hidden"
+          : cn("border rounded-md", className),
       )}
     >
-      {/* Fullscreen header */}
-      {isFullscreen && (
-        <div className="flex items-center justify-between px-4 py-2 border-b shrink-0">
-          <span className="text-sm font-medium text-muted-foreground">
-            Editing Content
-          </span>
-          <div className="flex items-center gap-3">
-            <span className="text-xs text-muted-foreground hidden sm:inline">
-              Press <kbd className="px-1.5 py-0.5 rounded border bg-muted text-[10px] font-mono">Esc</kbd> to exit
-            </span>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setIsFullscreen(false)}
-              className="gap-1.5"
-            >
-              <Minimize2 className="h-3.5 w-3.5" />
-              Exit Fullscreen
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {/* Toolbar */}
+      {/* Toolbar — always rendered; centered in fullscreen */}
       {editorInstance && (
         <MenuBar
           editor={editorInstance}
-          toggleModal={toggleFullscreen}
+          toggleFullscreen={toggleFullscreen}
           compact={isFullscreen ? false : compact}
           isFullscreen={isFullscreen}
         />
       )}
 
-      {/* Editor content — always mounted, never unmounts */}
+      {/* Scrollable content area */}
       <div
         className={cn(
-          "overflow-y-auto border-t",
-          isFullscreen ? "flex-1" : "",
+          "overflow-y-auto border-t flex-1",
+          !isFullscreen && "max-h-[300px]",
         )}
-        style={!isFullscreen ? { maxHeight: "300px" } : undefined}
       >
-        <div className={isFullscreen ? "max-w-4xl mx-auto px-8 py-6" : ""}>
+        <div className={cn(isFullscreen && "max-w-4xl mx-auto px-8 py-6")}>
           <EditorContent editor={editorInstance} className="max-w-none" />
         </div>
       </div>
+
+      {/* Fullscreen footer hint */}
+      {isFullscreen && (
+        <div className="shrink-0 border-t px-4 py-1.5 bg-muted/30 flex items-center justify-end gap-3">
+          <span className="text-xs text-muted-foreground">
+            Press{" "}
+            <kbd className="px-1.5 py-0.5 rounded border bg-muted text-[10px] font-mono">
+              Esc
+            </kbd>{" "}
+            or click <Minimize2 className="h-3 w-3 inline-block mx-0.5" /> to exit
+          </span>
+        </div>
+      )}
     </div>
   );
-
-  if (isFullscreen && typeof document !== "undefined") {
-    return createPortal(editorContent, document.body);
-  }
-
-  return editorContent;
 }

--- a/src/components/ui/tiptap-extensions/resizable-image-view.tsx
+++ b/src/components/ui/tiptap-extensions/resizable-image-view.tsx
@@ -3,6 +3,7 @@ import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import { cn } from "@/shared/utils";
 import { AlignLeft, AlignCenter, AlignRight, Trash2 } from "lucide-react";
+import { getEditorImageUrl } from "@/shared/image-optimizer";
 
 export function ResizableImageView({
   node,
@@ -17,7 +18,7 @@ export function ResizableImageView({
   const [displayWidth, setDisplayWidth] = useState<number | null>(null);
   const widthRef = useRef<number | null>(null);
 
-  // Reset display width when the attribute changes externally
+  // Reset display width when the stored attribute changes externally
   useEffect(() => {
     setDisplayWidth(null);
   }, [width]);
@@ -68,6 +69,12 @@ export function ResizableImageView({
     ? `${displayWidth}px`
     : width || undefined;
 
+  // Current pixel width for optimization hints
+  const currentWidthPx = displayWidth ?? (width ? parseInt(width, 10) : null);
+
+  // Display via optimized URL; original src is stored in the node attrs and preserved in HTML output
+  const displaySrc = getEditorImageUrl(src, currentWidthPx);
+
   const alignmentClass =
     textAlign === "center"
       ? "mx-auto"
@@ -87,7 +94,7 @@ export function ResizableImageView({
       >
         <img
           ref={imgRef}
-          src={src}
+          src={displaySrc}
           alt={alt || ""}
           className={cn(
             "block h-auto rounded-md",
@@ -100,7 +107,7 @@ export function ResizableImageView({
           draggable={false}
         />
 
-        {/* Floating toolbar - show when selected */}
+        {/* Floating toolbar — visible when selected, not while actively resizing */}
         {selected && !resizing && (
           <div className="absolute -top-10 left-1/2 -translate-x-1/2 flex items-center gap-0.5 bg-background border rounded-md shadow-lg p-0.5 z-20">
             <button
@@ -144,7 +151,7 @@ export function ResizableImageView({
           </div>
         )}
 
-        {/* Resize handle - right edge */}
+        {/* Right-edge resize handle */}
         {selected && (
           <div
             className="resize-handle right opacity-0 group-hover:opacity-100 transition-opacity"
@@ -152,7 +159,7 @@ export function ResizableImageView({
           />
         )}
 
-        {/* Resize handle - bottom-right corner */}
+        {/* Bottom-right corner resize handle */}
         {selected && (
           <div
             className="resize-handle bottom-right opacity-0 group-hover:opacity-100 transition-opacity"

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[1200] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className,
     )}
     {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -44,13 +44,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[200] w-fit rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[1100] w-fit rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[200] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[1100] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/src/shared/image-optimizer.ts
+++ b/src/shared/image-optimizer.ts
@@ -2,24 +2,35 @@
  * Image Optimization Utility for Cloudflare Images
  *
  * COST OPTIMIZATION STRATEGY:
- * - Uses ONE standard size (600x600) for ALL image displays
+ * - Uses ONE standard size (600x600) for ALL thumbnail/preview displays
  * - This prevents multiple transformations of the same image
  * - CSS handles display size variations (thumbnails, previews, etc.)
  * - Significantly reduces Cloudflare Image transformation costs
  *
- * WHY 600x600?
+ * WHY 600x600 for thumbnails?
  * - Large enough for most preview use cases
  * - Small enough to load quickly (typically 50-150KB vs 5-10MB original)
  * - Good balance between quality and performance
  * - Works well for both thumbnails and medium-sized displays
+ *
+ * DEV vs PRODUCTION:
+ * - In development (localhost), /cdn-cgi/image/ is not available (Cloudflare-only)
+ * - Images are served from their original R2 URLs without transformation
+ * - In production, Cloudflare Workers intercepts /cdn-cgi/image/ automatically
+ * - No extra env vars needed — dev detection is automatic by hostname
  */
 
 import { resolveMediaUrl } from "./media-url";
 
-// Standard optimized size for all images
+// Standard optimized size for thumbnail/list views
 const STANDARD_WIDTH = 600;
 const STANDARD_HEIGHT = 600;
 const STANDARD_QUALITY = 85;
+
+// Editor images are shown larger, so use higher max-width
+// Height is not constrained to preserve aspect ratio (fit=scale-down)
+const EDITOR_MAX_WIDTH = 1200;
+const EDITOR_QUALITY = 85;
 
 /**
  * Generates an optimized image URL using Cloudflare Image Resizing
@@ -69,6 +80,61 @@ export function getOptimizedImageUrl(originalUrl: string | null | undefined): st
 
   // Construct the optimized URL
   // Format: /cdn-cgi/image/{params}/{full-url-to-image}
+  return `/cdn-cgi/image/${params}/${resolved}`;
+}
+
+/**
+ * Generates an optimized image URL specifically for rich-text editor display.
+ *
+ * Differences from getOptimizedImageUrl:
+ * - Higher max resolution (1200px wide) since editor images can be large
+ * - Preserves aspect ratio (fit=scale-down, no height cap)
+ * - Includes onerror=redirect for graceful fallback on transform failure
+ * - Optionally uses the display width from image resizing
+ *
+ * In development: returns the resolved URL (no Cloudflare transform).
+ *
+ * @param originalUrl - The original image URL (from R2 or external)
+ * @param displayWidthPx - Optional display width in px; used when image has been resized
+ */
+export function getEditorImageUrl(
+  originalUrl: string | null | undefined,
+  displayWidthPx?: number | null,
+): string {
+  const resolved = resolveMediaUrl(originalUrl);
+  if (!resolved) return "";
+
+  if (resolved.includes("/cdn-cgi/image/")) {
+    return resolved;
+  }
+
+  const isDevelopment =
+    import.meta.env.MODE === "development" ||
+    import.meta.env.DEV === true ||
+    (typeof window !== "undefined" &&
+      (window.location.hostname === "localhost" ||
+       window.location.hostname === "127.0.0.1" ||
+       window.location.hostname.startsWith("192.168.") ||
+       window.location.hostname.includes("local"))) ||
+    (typeof process !== "undefined" && process.env.NODE_ENV === "development");
+
+  if (isDevelopment) {
+    return resolved;
+  }
+
+  // Use provided display width (capped) or fall back to editor max
+  const width = displayWidthPx
+    ? Math.min(Math.round(displayWidthPx * 1.5), EDITOR_MAX_WIDTH) // 1.5x for HiDPI screens
+    : EDITOR_MAX_WIDTH;
+
+  const params = [
+    `onerror=redirect`,
+    `width=${width}`,
+    `fit=scale-down`,
+    `quality=${EDITOR_QUALITY}`,
+    `format=auto`,
+  ].join(",");
+
   return `/cdn-cgi/image/${params}/${resolved}`;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhances the rich text editor with robust fullscreen functionality, Media Library integration, and optimized image loading.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses several issues:
- **Fullscreen Glitches:** Previously, entering fullscreen mode caused images and videos to disappear due to DOM reparenting. This is fixed by using CSS `position: fixed` and dynamically managing `view-transition-name` on the main layout to ensure the editor stays in the same DOM tree and appears above all other elements.
- **Image/Video Insertion:** A bug where inserting a video would replace a selected image is resolved by always appending new content at the absolute end of the document.
- **Media Library Integration:** Users can now insert images directly from the Media Library, which opens as a dialog with a higher z-index to function correctly within fullscreen mode.
- **Image Optimization:** Images displayed within the editor are now optimized using Cloudflare Workers in production and original URLs in development, ensuring consistent performance.
- **Z-index Hierarchy:** A comprehensive z-index overhaul ensures all editor elements, dialogs, popovers, and toasts stack correctly, especially in fullscreen mode.

---
<p><a href="https://cursor.com/agents/bc-8f0c9e40-5028-459c-8da1-f5e0c501e77d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0c9e40-5028-459c-8da1-f5e0c501e77d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->